### PR TITLE
feat(helper view): QR for helper import in ssp

### DIFF
--- a/src/registration/templates/registration/admin/view_helper.html
+++ b/src/registration/templates/registration/admin/view_helper.html
@@ -32,6 +32,13 @@
         </p>
     {% endif %}
 
+    {# stustapay qr code #}
+    <p>
+        <h2>{% trans "StuStaPay QR Code" %}</h2>
+        <img src="{{stustapay_qr_code}}" alt="StuStaPay QR Code" width="300" height="300">
+    </p>
+    <!-- <img src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data={'firstName': '{{helper.firstname}}', 'lastName': '{{helper.surname}}', 'description': 'Bierteamhelfer'}" alt="QR Code" width="150" height="150">  -->
+
     {# personal data #}
     <h2>{% trans "Personal data" %}</h2>
     <p>

--- a/src/registration/views/helper.py
+++ b/src/registration/views/helper.py
@@ -1,3 +1,6 @@
+import base64
+import io
+import json
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models.functions import TruncDate
@@ -5,6 +8,7 @@ from django.http import Http404
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import never_cache
+import qrcode
 
 from corona.forms import ContactTracingDataForm
 from gifts.forms import HelpersGiftsForm
@@ -169,6 +173,19 @@ def view_helper(request, event_url_name, helper_pk):
         messages.success(request, _("Changes were saved."))
         return redirect("view_helper", event_url_name=event.url_name, helper_pk=helper.pk)
 
+    # create qr code
+    stustapay_qr = dict(
+        firstName=helper.firstname,
+        lastName=helper.surname,
+        description=", ".join([i.job.name for i in helper.shifts.all()]),
+    )
+    img = qrcode.make(json.dumps(stustapay_qr))
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    buffer.seek(0)
+    img_png = buffer.getvalue()
+    stustapay_qr_b64 = base64.b64encode(img_png).decode("ascii")
+
     # render page
     context = {
         "event": event,
@@ -178,6 +195,7 @@ def view_helper(request, event_url_name, helper_pk):
         "internal_comment_form": internal_comment_form,
         "gifts_form": gifts_form,
         "prerequisites_form": prerequisites_form,
+        "stustapay_qr_code": f"data:image/png;base64,{stustapay_qr_b64}",
     }
     return render(request, "registration/admin/view_helper.html", context)
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -27,3 +27,4 @@ python-magic~=0.4
 pyyaml~=6.0
 reportlab~=4.0.4
 xlsxwriter~=3.0
+qrcode==8.2


### PR DESCRIPTION
Adds QR Code in helper view that can be used for account creation in stustapay, see [this PR in stustapay](https://github.com/stustapay/stustapay/pull/467)
- adds first and last name of the helper
- adds the shifts into the description field in stustapay